### PR TITLE
Update tx_pxaformenhancement_domain_model_form.php

### DIFF
--- a/Configuration/TCA/tx_pxaformenhancement_domain_model_form.php
+++ b/Configuration/TCA/tx_pxaformenhancement_domain_model_form.php
@@ -73,36 +73,38 @@ return [
                             'localize' => false,
                         ]
                     ],
-                    'foreign_types' => [
-                        '0' => [
-                            'showitem' => '
-							--palette--;' . $llImagePalette . '
-							--palette--;;filePalette'
-                        ],
-                        \TYPO3\CMS\Core\Resource\File::FILETYPE_TEXT => [
-                            'showitem' => '
-							--palette--;' . $llImagePalette . '
-							--palette--;;filePalette'
-                        ],
-                        \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
-                            'showitem' => '
-							--palette--;' . $llImagePalette . '
-							--palette--;;filePalette'
-                        ],
-                        \TYPO3\CMS\Core\Resource\File::FILETYPE_AUDIO => [
-                            'showitem' => '
-							--palette--;' . $llImagePalette . '
-							--palette--;;filePalette'
-                        ],
-                        \TYPO3\CMS\Core\Resource\File::FILETYPE_VIDEO => [
-                            'showitem' => '
-							--palette--;' . $llImagePalette . '
-							--palette--;;filePalette'
-                        ],
-                        \TYPO3\CMS\Core\Resource\File::FILETYPE_APPLICATION => [
-                            'showitem' => '
-							--palette--;' . $llImagePalette . '
-							--palette--;;filePalette'
+                    'overrideChildTca' => [
+                        'types' => [
+                            '0' => [
+                                'showitem' => '
+                                --palette--;' . $llImagePalette . '
+                                --palette--;;filePalette'
+                            ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_TEXT => [
+                                'showitem' => '
+                                --palette--;' . $llImagePalette . '
+                                --palette--;;filePalette'
+                            ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
+                                'showitem' => '
+                                --palette--;' . $llImagePalette . '
+                                --palette--;;filePalette'
+                            ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_AUDIO => [
+                                'showitem' => '
+                                --palette--;' . $llImagePalette . '
+                                --palette--;;filePalette'
+                            ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_VIDEO => [
+                                'showitem' => '
+                                --palette--;' . $llImagePalette . '
+                                --palette--;;filePalette'
+                            ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_APPLICATION => [
+                                'showitem' => '
+                                --palette--;' . $llImagePalette . '
+                                --palette--;;filePalette'
+                            ]
                         ]
                     ],
                     'maxitems' => 99


### PR DESCRIPTION
TCA migrations need to be applied

The 'foreign_types' property from TCA tx_pxaformenhancement_domain_model_form['columns']['attachments']['config'] and has been migrated to tx_pxaformenhancement_domain_model_form['columns']['attachments']['config']['overrideChildTca']['types']