### PR TITLE
Fixed error on image upload in Backend.

### DIFF
--- a/Configuration/TCA/tx_pxaformenhancement_domain_model_form.php
+++ b/Configuration/TCA/tx_pxaformenhancement_domain_model_form.php
@@ -72,32 +72,32 @@ return [
                         'types' => [
                             '0' => [
                                 'showitem' => '
-                                --palette--;' . $llImagePalette . '
+                                --palette--;' . $llImagePalette . ',
                                 --palette--;;filePalette'
                             ],
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_TEXT => [
                                 'showitem' => '
-                                --palette--;' . $llImagePalette . '
+                                --palette--;' . $llImagePalette . ',
                                 --palette--;;filePalette'
                             ],
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
                                 'showitem' => '
-                                --palette--;' . $llImagePalette . '
+                                --palette--;' . $llImagePalette . ',
                                 --palette--;;filePalette'
                             ],
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_AUDIO => [
                                 'showitem' => '
-                                --palette--;' . $llImagePalette . '
+                                --palette--;' . $llImagePalette . ',
                                 --palette--;;filePalette'
                             ],
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_VIDEO => [
                                 'showitem' => '
-                                --palette--;' . $llImagePalette . '
+                                --palette--;' . $llImagePalette . ',
                                 --palette--;;filePalette'
                             ],
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_APPLICATION => [
                                 'showitem' => '
-                                --palette--;' . $llImagePalette . '
+                                --palette--;' . $llImagePalette . ',
                                 --palette--;;filePalette'
                             ]
                         ]


### PR DESCRIPTION
Added missing commas in TCA which are responsible for an error in Backend that is preventing a user from creating a file_references. This error ist also present in Typo3 version 9 from this extension, it would be nice to have this fixed as well.
